### PR TITLE
support compress with zlib

### DIFF
--- a/aliyun/log/putlogsrequest.py
+++ b/aliyun/log/putlogsrequest.py
@@ -25,11 +25,15 @@ class PutLogsRequest(LogRequest):
     :type logitems: list<LogItem>
     :param logitems: log data
 
-    :type logtags: list 
-    :param logtags: list of key:value tag pair , [(tag_key_1,tag_value_1) , (tag_key_2,tag_value_2)]
-
     :type hashKey: String
     :param hashKey: put data with set hash, the data will be send to shard whose range contains the hashKey
+
+    :type compress: bool
+    :param compress: if need to compress the logs
+
+    :type logtags: list
+    :param logtags: list of key:value tag pair , [(tag_key_1,tag_value_1) , (tag_key_2,tag_value_2)]
+
     """
 
     def __init__(self, project=None, logstore=None, topic=None, source=None, logitems=None, hashKey=None,

--- a/tests/sample.py
+++ b/tests/sample.py
@@ -8,7 +8,7 @@ import time
 import os
 
 
-def sample_put_logs(client, project, logstore):
+def sample_put_logs(client, project, logstore, compress=False):
     topic = 'TestTopic_2'
     source = ''
     contents = [
@@ -21,7 +21,7 @@ def sample_put_logs(client, project, logstore):
     logItem.set_contents(contents)
     for i in range(0, 1):
         logitemList.append(logItem)
-    request = PutLogsRequest(project, logstore, topic, source, logitemList)
+    request = PutLogsRequest(project, logstore, topic, source, logitemList, compress=compress)
 
     response = client.put_logs(request)
     response.log_print()
@@ -39,12 +39,12 @@ def sample_put_logs(client, project, logstore):
     res.log_print()
 
 # @log_enter_exit
-def sample_pull_logs(client, project, logstore):
+def sample_pull_logs(client, project, logstore, compress=False):
     res = client.get_cursor(project, logstore, 0, int(time.time() - 60))
     res.log_print()
     cursor = res.get_cursor()
 
-    res = client.pull_logs(project, logstore, 0, cursor, 1)
+    res = client.pull_logs(project, logstore, 0, cursor, 1, compress=compress)
     res.log_print()
 
 # @log_enter_exit
@@ -258,8 +258,10 @@ def main():
     sample_list_topics(client, project, logstore)
     time.sleep(40)
     sample_put_logs(client, project, logstore)
+    sample_put_logs(client, project, logstore, compress=True)
 
     sample_pull_logs(client, project, logstore)
+    sample_pull_logs(client, project, logstore, compress=True)
 
     time.sleep(40)
     sample_get_logs(client, project, logstore)


### PR DESCRIPTION
1. use zip when passing compress=True to putLogs
2. getLogs will ask zip format from server and parsing content dynamically basing on x-log-compressiontype header rather than API parameter.